### PR TITLE
It's better to control the service state seperately from this role

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -14,6 +14,3 @@
 
 - shell: systemctl daemon-reload
   when: service_file.changed and not ansible_unit_test
-
-- service: name="{{ systemd_service_name }}" state=started enabled=yes
-  when: not ansible_unit_test


### PR DESCRIPTION
Often it's not helpful that this role is directly starting the service, I think the state of a service should be managed in a seperate role. E.g. I'm using the systemd-service role as a dependency of the role installing  the service which is very useful. Nervertheless, when the role is running, the service is might not installed yet, so it would be better to just handle the systemd configuration files within this role.
