### PR TITLE
Service: Add RestartSec param

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Role Variables
 |`systemd_service_Service_ExecStart` * |String||[Service]ExecStart
 |`systemd_service_Service_ExecStartPost`|String,List||[Service]ExecStartPost
 |`systemd_service_Service_Restart`|String|"no"| [Service]Restart "no" or "always" or "on-success" or "on-failure"
+|`systemd_service_Service_RestartSec`|Integer|| [Service]RestartSec
 |`systemd_service_Service_ExecReload`|String|| [Service]ExecReload
 |`systemd_service_Service_ExecStop`|String|| [Service]ExecStop
 |`systemd_service_Service_ExecStopPost`|String,List|| [Service]ExecStopPost

--- a/templates/service.j2
+++ b/templates/service.j2
@@ -90,6 +90,9 @@ BusName={{ systemd_service_Service_BusName }}
 {% if systemd_service_Service_Restart is defined %}
 Restart={{ systemd_service_Service_Restart }}
 {% endif %}
+{% if systemd_service_Service_RestartSec is defined %}
+RestartSec={{ systemd_service_Service_RestartSec }}
+{% endif %}
 {% if systemd_service_Service_PrivateTmp is defined %}
 Service_PrivateTmp={{ systemd_service_Service_PrivateTmp }}
 {% endif -%}

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -60,6 +60,7 @@
         - start post 1
         - start post 2
       systemd_service_Service_Restart: restart
+      systemd_service_Service_RestartSec: 10
       systemd_service_Service_ExecReload: reload
       systemd_service_Service_ExecStop: stop
       systemd_service_Service_ExecStopPost: stop post


### PR DESCRIPTION
Add the RestartSec param inside the j2 template (service section).

  RestartSec=
      Configures the time to sleep before restarting a service (as
      configured with Restart=). Takes a unit-less value inds, or a
      time span value such as "5min 20s". Defaults to 100ms.