### PR TITLE
Add systemd_service_Service_KillMode support

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Role Variables
 |`systemd_service_Service_RestartSec`|Integer|| [Service]RestartSec
 |`systemd_service_Service_ExecReload`|String|| [Service]ExecReload
 |`systemd_service_Service_ExecStop`|String|| [Service]ExecStop
+|`systemd_service_Service_KillMode`|String|| [Service]KillMode
 |`systemd_service_Service_ExecStopPost`|String,List|| [Service]ExecStopPost
 |`systemd_service_Service_PIDFile`|String|| [Service]PIDFile
 |`systemd_service_Service_BusName`|String|| [Service]BusName

--- a/templates/service.j2
+++ b/templates/service.j2
@@ -56,6 +56,9 @@ ExecReload={{ systemd_service_ExecReload }}
 {% if systemd_service_Service_ExecStop is defined %}
 ExecStop={{ systemd_service_Service_ExecStop }}
 {% endif -%}
+{% if systemd_service_Service_KillMode is defined %}
+KillMode={{ systemd_service_Service_KillMode }}
+{% endif -%}
 
 {% if systemd_service_Service_ExecStartPre is defined %}
 {% if systemd_service_Service_ExecStartPre is string %}


### PR DESCRIPTION
Hi

Like [haproxy.service](http://git.haproxy.org/?p=haproxy-1.7.git;a=blob;f=contrib/systemd/haproxy.service.in;h=dca81a263ee122fbbd567454a2b1c5035e92a16b;hb=HEAD#l11) , the [ExecStop](https://www.freedesktop.org/software/systemd/man/systemd.service.html#ExecStop=) require [KillMode](https://www.freedesktop.org/software/systemd/man/systemd.kill.html#KillMode=) , so I made this PR.

Please review, thanks.