### PR TITLE
Fixed hardcoded path to environment file

### DIFF
--- a/templates/service.j2
+++ b/templates/service.j2
@@ -39,7 +39,7 @@ After={{ systemd_service_Unit_After | join(",") }}
 
 [Service]
 ExecStart={{ systemd_service_Service_ExecStart }}
-EnvironmentFile=-/etc/default/{{ systemd_service_name }}
+EnvironmentFile=-{{ systemd_service_default_dir }}/{{ systemd_service_name }}
 Type={{ systemd_service_Service_Type }}
 
 {% if systemd_service_Service_User is defined %}


### PR DESCRIPTION
The environment file is automatically templated into {{ systemd_service_default_dir }}, but the unit file template has a hardcoded path to /etc/default
Since I don't know about the role unit testing, I don't know if {{ ansible_unit_test_prefix_dir }} also needs to be part of the templated path.