### PR TITLE
Add LimitNOFILE systemd parameter to specify Number of File descriptors

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ Role Variables
 |`systemd_service_Service_PIDFile`|String|| [Service]PIDFile
 |`systemd_service_Service_BusName`|String|| [Service]BusName
 |`systemd_service_Service_PrivateTmp`|String|| [Service]PrivateTmp
+|`systemd_service_Service_LimitNOFILE`|String|| [Service]LimitNOFILE
 |`systemd_service_Service_User`|String|| [Service]User
 |`systemd_service_Service_Group`|String|| [Service]Group
 |`systemd_service_Service_WorkingDirectory`|String|| [Service]WorkingDirectory

--- a/templates/service.j2
+++ b/templates/service.j2
@@ -109,6 +109,10 @@ RestartSec={{ systemd_service_Service_RestartSec }}
 PrivateTmp={{ systemd_service_Service_PrivateTmp }}
 {% endif -%}
 
+{% if systemd_service_Service_LimitNOFILE is defined %}
+LimitNOFILE={{ systemd_service_Service_LimitNOFILE }}
+{% endif -%}
+
 [Install]
 {% if systemd_service_Install_WantedBy is defined %}
 WantedBy={{ systemd_service_Install_WantedBy }}

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -67,6 +67,7 @@
       systemd_service_Service_PIDFile: pid
       systemd_service_Service_BusName: bus
       systemd_service_Service_PrivateTmp: tmp
+      systemd_service_Service_LimitNOFILE: 65536
       systemd_service_Install_WantedBy: wantedby
       systemd_service_Install_RequiredBy: requiredby
       systemd_service_Install_Also: also


### PR DESCRIPTION
…Descriptors

Link : https://www.freedesktop.org/software/systemd/man/systemd.exec.html

Add new `systemd_service_Service_LimitNOFILE` parameter to be able to specify
the number of file descriptors for the systemd service `LimitNOFILE`.