### PR TITLE
Use `become` for privilege escalation

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,6 +1,7 @@
 ---
 # handlers file for roles/systemd/service
 - name: reload systemd
+  become: yes
   shell: |
     service "{{ systemd_service_name }}" restart
   when: not ansible_unit_test

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,16 +1,20 @@
 ---
 # tasks file for roles/systemd/service
 - file: state=directory path="{{ item }}" recurse=yes
+  become: yes
   with_items:
     - "{{ ansible_unit_test_prefix_dir }}{{ systemd_service_default_dir }}"
     - "{{ ansible_unit_test_prefix_dir }}{{ systemd_service_systemd_dir }}"
 
 - template: src="default.j2" dest="{{ ansible_unit_test_prefix_dir }}/{{ systemd_service_default_dir }}/{{ systemd_service_name }}"
+  become: yes
   notify: reload systemd
 
 - template: src="service.j2" dest="{{ ansible_unit_test_prefix_dir }}/{{ systemd_service_systemd_dir }}/{{ systemd_service_name }}.service"
+  become: yes
   register: service_file
   notify: reload systemd
 
 - shell: systemctl daemon-reload
+  become: yes
   when: service_file.changed and not ansible_unit_test


### PR DESCRIPTION
`become` is required to correctly handle privilege escalation when Ansible does not connect to the remote as the root user. 

I've added the `become` but I'm unsure how to make this work with your Travis setup. Either sudo is required in the test environment or the `become_user` should be set (or the tests could be ran in Docker). I couldn't get the `become_user` change working when I took a quick look at the test harness.